### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  packages: write
+  actions: write
+
 env:
   BUILD_CONFIGURATION: Release
   DOTNET_VERSION: '8.0.x'


### PR DESCRIPTION
Potential fix for [https://github.com/ShigureDD/2048WindSurf/security/code-scanning/2](https://github.com/ShigureDD/2048WindSurf/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for the workflow. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for accessing the repository's contents.
- `packages: write` for uploading release assets.
- `actions: write` for creating releases.

This ensures that the workflow has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
